### PR TITLE
Include modified files in the generated matrix zip

### DIFF
--- a/addon_submitter/utils.py
+++ b/addon_submitter/utils.py
@@ -58,11 +58,15 @@ def create_zip(zip_name, addon_id, subdirectory):
     """
     logger.info('Creating ZIP file...')
     if subdirectory:
-        shell('git', 'archive', '-o', '{}.zip'.format(zip_name), 'HEAD', '--',
-              addon_id)
+        shell(
+            'sh', '-c',
+            'HASH=$(git stash create); git archive -o %s.zip ${HASH:-HEAD} -- %s' % (zip_name, addon_id)
+        )
     else:
-        shell('git', 'archive', '-o', '{}.zip'.format(zip_name),
-              '--prefix', '{}/'.format(addon_id), 'HEAD')
+        shell(
+            'sh', '-c',
+            'HASH=$(git stash create); git archive -o %s.zip --prefix %s/ ${HASH:-HEAD}' % (zip_name, addon_id)
+        )
     logger.info('ZIP created successfully.')
 
 


### PR DESCRIPTION
This modifies the `create_zip` method so it includes the changes made to the addon.xml.

By specifying `HEAD`, git will pick the latest committed changes. We can do a `git stash create` to create a git object that will contain all the modifications made and use that. Since this won't work when there are no actual changes done, we use variable substitution so we safely fallback to HEAD.

Fixes #19 