### PR TITLE
Revert "Include modified files in the generated matrix zip"

### DIFF
--- a/addon_submitter/utils.py
+++ b/addon_submitter/utils.py
@@ -58,15 +58,11 @@ def create_zip(zip_name, addon_id, subdirectory):
     """
     logger.info('Creating ZIP file...')
     if subdirectory:
-        shell(
-            'sh', '-c',
-            'HASH=$(git stash create); git archive -o %s.zip ${HASH:-HEAD} -- %s' % (zip_name, addon_id)
-        )
+        shell('git', 'archive', '-o', '{}.zip'.format(zip_name), 'HEAD', '--',
+              addon_id)
     else:
-        shell(
-            'sh', '-c',
-            'HASH=$(git stash create); git archive -o %s.zip --prefix %s/ ${HASH:-HEAD}' % (zip_name, addon_id)
-        )
+        shell('git', 'archive', '-o', '{}.zip'.format(zip_name),
+              '--prefix', '{}/'.format(addon_id), 'HEAD')
     logger.info('ZIP created successfully.')
 
 


### PR DESCRIPTION
Reverts xbmc/kodi-addon-submitter#20

This seems to have an issue when submitting the actual addon. I think that the `git stash create` causes the actual commit to fail. I'll probably have to `git stash pop` or find a better solution.

I think it's best to revert this for now, so the Github Action works again.