### PR TITLE
Use https for repo url

### DIFF
--- a/addon_submitter/utils.py
+++ b/addon_submitter/utils.py
@@ -141,7 +141,7 @@ def create_addon_branch(work_dir, repo, branch, addon_id, version, subdirectory,
     if os.path.exists(repo_dir):
         shutil.rmtree(repo_dir)
     shell('git', 'clone', '--branch', branch, '--origin', 'upstream',
-          '--single-branch', 'git://github.com/xbmc/{}.git'.format(repo))
+          '--single-branch', 'https://github.com/xbmc/{}.git'.format(repo))
     os.chdir(repo)
     shell('git', 'config', '--global', 'user.name', '{}'.format(gh_username))
     shell('git', 'config', '--global', 'user.email', user_email)


### PR DESCRIPTION
git:// urls are deprecated by Github.

```
The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information
```