### PR TITLE
Do not raise an exception if a pull request already exists

### DIFF
--- a/addon_submitter/utils.py
+++ b/addon_submitter/utils.py
@@ -283,7 +283,7 @@ def create_pull_request(repo, upstream_branch, local_branch, addon_info,
             )
         logger.info('Pull request submitted successfully:')
     elif resp.status_code == 200 and resp.json():
-        raise AddonSubmissionError(
+        logger.info(
             'Pull request in {} for {}:{} already exists.'.format(
                 upstream_branch, gh_username, local_branch)
         )


### PR DESCRIPTION
This PR reverts PR #27 that has broken the ability to update existing pull requests, e.g. after implementing changes requested by a reviewer.